### PR TITLE
Support dashes in key names

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -26,7 +26,7 @@ var grammar = {
             [ '[0-9]+(?:\\.[0-9]+)?\\b', 'return "NUMBER";' ], // 212.321
             [ 'true|false', 'return "BOOLEAN";' ], // true/false
             [ 'null|undefined', 'return "PRIMITIVE";' ],
-            [ '[a-zA-Z_][\\.a-zA-Z0-9_]*', 'return "SYMBOL";' ], // some.Symbol22
+            [ '[a-zA-Z_][\\.a-zA-Z0-9_-]*', 'return "SYMBOL";' ], // some.Symbol22
             [ '"(?:[^"])*"', 'yytext = yytext.substr(1, yyleng-2); return "STRING";' ], // "foo"
 
             // End


### PR DESCRIPTION
Dashes are valid in json key names but are not supported in the regex, this PR fixes that.
